### PR TITLE
Change `__DIR__` to `dirname(__FILE__)` in order to works with PHP 5.2.4...

### DIFF
--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -16,7 +16,7 @@
  * @copyright 			Copyright (c) 2012 Edmundas Kondrašovas <as@edmundask.lt>
  */
 
-if(!defined('TWIGGY_ROOT')) define('TWIGGY_ROOT', dirname(__DIR__));
+if(!defined('TWIGGY_ROOT')) define('TWIGGY_ROOT', dirname(dirname(__FILE__)));
 
 require_once(TWIGGY_ROOT . '/vendor/Twig/lib/Twig/Autoloader.php');
 Twig_Autoloader::register();


### PR DESCRIPTION
...+

The magic constant `__DIR__` was added in PHP 5.3.0, as said here: http://php.net/manual/en/language.constants.predefined.php
