### PR TITLE
Registering all a helpers/libraries functions at once

### DIFF
--- a/config/twiggy.php
+++ b/config/twiggy.php
@@ -3,10 +3,10 @@
 /**
  * Twiggy - Twig template engine implementation for CodeIgniter
  *
- * Twiggy is not just a simple implementation of Twig template engine 
+ * Twiggy is not just a simple implementation of Twig template engine
  * for CodeIgniter. It supports themes, layouts, templates for regular
  * apps and also for apps that use HMVC (module support).
- * 
+ *
  * @package   			CodeIgniter
  * @subpackage			Twiggy
  * @category  			Config
@@ -36,7 +36,7 @@ $config['twiggy']['template_file_ext'] = '.html.twig';
 | Syntax Delimiters
 |--------------------------------------------------------------------------
 |
-| If you don't like the default Twig syntax delimiters or if they collide 
+| If you don't like the default Twig syntax delimiters or if they collide
 | with other languages (for example, you use handlebars.js in your
 | templates), here you can change them.
 |
@@ -73,7 +73,7 @@ $config['twiggy']['delimiters'] = array
 | NOTE: cache option works slightly differently than in Twig. In Twig you
 | can either set the value to FALSE to disable caching, or set the path
 | to where the cached files should be stored (which means caching would be
-| enabled in that case). This is not entirely convenient if you need to 
+| enabled in that case). This is not entirely convenient if you need to
 | switch between enabled or disabled caching for debugging or other reasons.
 |
 | Therefore, here the value can be either TRUE or FALSE. Cache directory
@@ -108,7 +108,7 @@ $config['twiggy']['twig_cache_dir'] = APPPATH . 'cache/twig/';
 | Themes Base Dir
 |--------------------------------------------------------------------------
 |
-| Directory where themes are located at. This path is relative to 
+| Directory where themes are located at. This path is relative to
 | CodeIgniter's base directory OR module's base directory. For example:
 |
 | $config['themes_base_dir'] = 'themes/';
@@ -118,7 +118,7 @@ $config['twiggy']['twig_cache_dir'] = APPPATH . 'cache/twig/';
 | {APPPATH}/themes/ and {APPPATH}/modules/{some_module}/themes/.
 |
 | NOTE: modules do not necessarily need to be in {APPPATH}/modules/ as
-| Twiggy will figure out the paths by itself. That way you can package 
+| Twiggy will figure out the paths by itself. That way you can package
 | your modules with themes.
 |
 | Also, do not forget the trailing slash!
@@ -186,12 +186,22 @@ $config['twiggy']['default_template'] = 'index';
 | Here you can list all the functions that you want Twiggy to automatically
 | register them for you.
 |
-| NOTE: only registered functions can be used in Twig templates. 
+| NOTE: only registered functions can be used in Twig templates.
 |
 */
 
 $config['twiggy']['register_functions'] = array
 (
+
+);
+
+//REGISTER A COMPLETE HELPER (WITH ALL ITS FUNCTIONS) AT ONCE
+$config['twiggy']['register_helper_functions'] = array(
+		'form_helper'
+);
+
+//REGISTER A COMPLETE LIBRARY (WITH ALL ITS FUNCTIONS) AT ONCE
+$config['twiggy']['register_library_functions'] = array(
 
 );
 
@@ -201,7 +211,7 @@ $config['twiggy']['register_functions'] = array
 | Auto-reigster filters
 |--------------------------------------------------------------------------
 |
-| Much like with functions, list filters that you want Twiggy to 
+| Much like with functions, list filters that you want Twiggy to
 | automatically register them for you.
 |
 | NOTE: only registered filters can be used in Twig templates. Also, keep
@@ -220,7 +230,7 @@ $config['twiggy']['register_filters'] = array
 | Title separator
 |--------------------------------------------------------------------------
 |
-| Lets you specify the separator used in separating sections of the title 
+| Lets you specify the separator used in separating sections of the title
 | variable.
 |
 */

--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -3,10 +3,10 @@
 /**
  * Twiggy - Twig template engine implementation for CodeIgniter
  *
- * Twiggy is not just a simple implementation of Twig template engine 
+ * Twiggy is not just a simple implementation of Twig template engine
  * for CodeIgniter. It supports themes, layouts, templates for regular
  * apps and also for apps that use HMVC (module support).
- * 
+ *
  * @package   			CodeIgniter
  * @subpackage			Twiggy
  * @category  			Libraries
@@ -38,7 +38,7 @@ class Twiggy
 	private $_module;
 	private $_meta = array();
 	private $_rendered = FALSE;
-	
+
 	/**
 	* Constructor
 	*/
@@ -66,7 +66,7 @@ class Twiggy
 
 		// Decide whether to enable Twig cache. If it is set to be enabled, then set the path where cached files will be stored.
 		$this->_config['environment']['cache'] = ($this->_config['environment']['cache']) ? $this->_config['twig_cache_dir'] : FALSE;
-		
+
 		$this->_twig = new Twig_Environment($this->_twig_loader, $this->_config['environment']);
 		$this->_twig->setLexer(new Twig_Lexer($this->_twig, $this->_config['delimiters']));
 
@@ -81,6 +81,38 @@ class Twiggy
 			foreach($this->_config['register_functions'] as $function) $this->register_function($function);
 		}
 
+		//@todo - REGISTER A WHOLE HELPERS FUNCTIONS AT ONCE
+		if(count($this->_config['register_helper_functions']) > 0)
+		{
+			$CI =& get_instance();
+			$CI->load->library('twiggy_tools');//using an external function for processing..
+
+			foreach($this->_config['register_helper_functions'] as $hfunction)
+			{
+				$funcs = $CI->twiggy_tools->get_defined_functions_in_helper($hfunction);//use imported func
+				foreach($funcs as $func)
+				{
+					$this->register_function($func);
+				}
+			}
+		}
+
+		//@TODO - REGISTER A WHOLE LIBRARIES FUNCTIONS AT ONCE
+		if(count($this->_config['register_library_functions']) > 0)
+		{
+			foreach($this->_config['register_library_functions'] as $lfunction)
+			{
+				$CI =& get_instance();//get an instance to use
+				$CI->load->library($lfunction);//load the library
+				$libfuncs = get_class_methods($CI->$lfunction);
+				foreach($libfuncs as $func)
+				{
+					$this->register_function($func);
+				}
+			}
+		}
+
+
 		if(count($this->_config['register_filters']) > 0)
 		{
 			foreach($this->_config['register_filters'] as $filter) $this->register_filter($filter);
@@ -92,7 +124,7 @@ class Twiggy
 
 	/**
 	 * Set data
-	 * 
+	 *
 	 * @access	public
 	 * @param 	mixed  	key (variable name) or an array of variable names with values
 	 * @param 	mixed  	data
@@ -116,7 +148,7 @@ class Twiggy
 			else
 			{
 			 	$this->_data[$key] = $value;
-			}	
+			}
 		}
 
 		return $this;
@@ -124,7 +156,7 @@ class Twiggy
 
 	/**
 	 * Unset a particular variable
-	 * 
+	 *
 	 * @access	public
 	 * @param 	mixed  	key (variable name)
 	 * @return	object 	instance of this class
@@ -139,9 +171,9 @@ class Twiggy
 
 	/**
 	 * Set title
-	 * 
+	 *
 	 * @access	public
-	 * @param 	string	
+	 * @param 	string
 	 * @return	object 	instance of this class
 	 */
 
@@ -151,7 +183,7 @@ class Twiggy
 		{
 			$args = func_get_args();
 
-			// If at least one parameter is passed in to this method, 
+			// If at least one parameter is passed in to this method,
 			// call append() to either set the title or append additional
 			// string data to it.
 			call_user_func_array(array($this, 'append'), $args);
@@ -162,9 +194,9 @@ class Twiggy
 
 	/**
 	 * Append string to the title
-	 * 
+	 *
 	 * @access	public
-	 * @param 	string	
+	 * @param 	string
 	 * @return	object 	instance of this class
 	 */
 
@@ -187,9 +219,9 @@ class Twiggy
 
 	/**
 	 * Prepend string to the title
-	 * 
+	 *
 	 * @access	public
-	 * @param 	string	
+	 * @param 	string
 	 * @return	object 	instance of this class
 	 */
 
@@ -212,7 +244,7 @@ class Twiggy
 
 	/**
 	 * Set title separator
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	separator
 	 * @return	object 	instance of this class
@@ -227,7 +259,7 @@ class Twiggy
 
 	/**
 	 * Set meta data
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	name
 	 * @param	string	value
@@ -244,7 +276,7 @@ class Twiggy
 
 	/**
 	 * Unset meta data
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	(optional) name of the meta tag
 	 * @return	object	instance of this class
@@ -271,7 +303,7 @@ class Twiggy
 
 	/**
 	 * Register a function in Twig environment
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	the name of an existing function
 	 * @return	object	instance of this class
@@ -286,7 +318,7 @@ class Twiggy
 
 	/**
 	 * Register a filter in Twig environment
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	the name of an existing function
 	 * @return	object	instance of this class
@@ -305,7 +337,7 @@ class Twiggy
 	* @access	public
 	* @param 	string	name of theme to load
 	* @return	object	instance of this class
-	*/       	
+	*/
 
 	public function theme($theme)
 	{
@@ -323,7 +355,7 @@ class Twiggy
 
 	/**
 	 * Set layout
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	name of the layout
 	 * @return	object	instance of this class
@@ -339,7 +371,7 @@ class Twiggy
 
 	/**
 	 * Set template
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	name of the template file
 	 * @return	object	instance of this class
@@ -354,7 +386,7 @@ class Twiggy
 
 	/**
 	 * Compile meta data into pure HTML
-	 * 
+	 *
 	 * @access	private
 	 * @return	string	HTML
 	 */
@@ -373,7 +405,7 @@ class Twiggy
 
 	/**
 	 * Convert meta tag array to HTML code
-	 * 
+	 *
 	 * @access	private
 	 * @param 	array 	meta tag
 	 * @return	string	HTML code
@@ -386,7 +418,7 @@ class Twiggy
 
 	/**
 	 * Load template and return output object
-	 * 
+	 *
 	 * @access	private
 	 * @return	object	output
 	 */
@@ -401,7 +433,7 @@ class Twiggy
 
 	/**
 	 * Render and return compiled HTML
-	 * 
+	 *
 	 * @access	public
 	 * @param 	string	(optional) template file
 	 * @return	string	compiled HTML
@@ -455,7 +487,7 @@ class Twiggy
 	{
 		// Reset template locations array since we loaded a different theme
 		//$this->_template_locations = array();
-		
+
 		// Check if HMVC is installed.
 		// NOTE: there may be a simplier way to check it but this seems good enough.
 		if(method_exists($this->CI->router, 'fetch_module'))

--- a/vendor/twiggy_tools.php
+++ b/vendor/twiggy_tools.php
@@ -1,0 +1,67 @@
+<?php if (!defined('BASEPATH'))
+	exit('No direct script access allowed');
+
+
+class Twiggy_tools {
+
+//my little addition for loading all helper functions at once
+
+	function get_defined_functions_in_helper($helper) {
+		if (file_exists("system/helpers/" . $helper . ".php")){//a native helper?
+			$file = "system/helpers/" . $helper . ".php";
+		}
+		if (file_exists("application/helpers/" . $helper . ".php")){//a custom helper?
+			$file = "application/helpers/" . $helper . ".php";
+		}
+		$source = file_get_contents($file);
+		$tokens = token_get_all($source);
+
+		$functions = array();
+		$nextStringIsFunc = false;
+		$inClass = false;
+		$bracesCount = 0;
+
+		foreach ($tokens as $token) {
+			switch ($token[0]) {
+			case T_CLASS:
+				$inClass = true;
+				break;
+			case T_FUNCTION:
+				if (!$inClass)
+					$nextStringIsFunc = true;
+				break;
+
+			case T_STRING:
+				if ($nextStringIsFunc) {
+					$nextStringIsFunc = false;
+					$functions[] = $token[1];
+				}
+				break;
+
+			// Anonymous functions
+			case '(':
+			case ';':
+				$nextStringIsFunc = false;
+				break;
+
+			// Exclude Classes
+			case '{':
+				if ($inClass)
+					$bracesCount++;
+				break;
+
+			case '}':
+				if ($inClass) {
+					$bracesCount--;
+					if ($bracesCount === 0)
+						$inClass = false;
+				}
+				break;
+			}
+		}
+
+		return $functions;
+
+	}
+
+}


### PR DESCRIPTION
Two new config arrays that allow a user to input a helper or library name and register all of its functions at once, without the need to individually register each function.
