### PR TITLE
Sparks and Composer support

### DIFF
--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -18,7 +18,9 @@
 
 if(!defined('TWIGGY_ROOT')) define('TWIGGY_ROOT', dirname(dirname(__FILE__)));
 
-require_once(TWIGGY_ROOT . '/vendor/Twig/lib/Twig/Autoloader.php');
+//If you don't like composer but love sparks. POSER!
+if ( !class_exists('ComposerAutoloaderInit') )
+	require_once(TWIGGY_ROOT . '/vendor/Twig/lib/Twig/Autoloader.php');
 Twig_Autoloader::register();
 
 class Twiggy


### PR DESCRIPTION
One more commit!

I'm using composer (sorry, don't like the spark's way). But if i follow your instructions, well, i get a crash, because composer loads the library different.

Well, cry no more! I just made a check, if there is a composer class loaded, your library will not include the file (composer is our friend, he already did it).

Sorry about my mood, but today is friday friday, got get down on friday :)
