### PR TITLE
Fixed bug which prevents assigning multiple variables at once

### DIFF
--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -102,7 +102,7 @@ class Twiggy
 	 * @return	object 	instance of this class
 	 */
 
-	public function set($key, $value, $global = FALSE)
+	public function set($key, $value = NULL, $global = FALSE)
 	{
 		if(is_array($key))
 		{


### PR DESCRIPTION
If trying to use 'set' method with only one parameter error was shown
because $value was not defined. Setting a default value of NULL
resolves this.
