### PR TITLE
Change the order of templates passed to twig

### DIFF
--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -485,6 +485,8 @@ class Twiggy
 		// Reset the paths if needed.
 		if(is_object($this->_twig_loader))
 		{
+			//lets make twig check our themes before falling back to the default.
+			$this->_template_locations = array_reverse($this->_template_locations);
 			$this->_twig_loader->setPaths($this->_template_locations);
 		}
 	}


### PR DESCRIPTION
I found that when using multiple themes the order of the template locations passed twig would cause loading of the default them even if I'd specified an alternate theme.

```
$this->twiggy->theme('homepage')->display('welcome');
```

```
Unable to find template "_layouts/index.html.twig" (looked into: application/themes/default, application/themes/default, application/themes/homepage).
```
