### PR TITLE
Fix Lexer / Function & Filter issues when using Twig2

### DIFF
--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -70,7 +70,6 @@ class Twiggy
 		$this->_config['environment']['cache'] = ($this->_config['environment']['cache']) ? $this->_config['twig_cache_dir'] : FALSE;
 		
 		$this->_twig = new Twig_Environment($this->_twig_loader, $this->_config['environment']);
-		$this->_twig->setLexer(new Twig_Lexer($this->_twig, $this->_config['delimiters']));
 
 		// Initialize defaults
 		$this->theme($this->_config['default_theme'])
@@ -397,8 +396,10 @@ class Twiggy
 	{
 		$this->set('meta', $this->_compile_metadata(), TRUE);
 		$this->_rendered = TRUE;
+		
+		$this->_twig->setLexer(new Twig_Lexer($this->_twig, $this->_config['delimiters']));
 
-		return $this->_twig->loadTemplate($this->_template . $this->_config['template_file_ext']);
+		return $this->_twig->load($this->_template . $this->_config['template_file_ext']);
 	}
 
 	/**

--- a/libraries/Twiggy.php
+++ b/libraries/Twiggy.php
@@ -280,7 +280,10 @@ class Twiggy
 
 	public function register_function($name)
 	{
-		$this->_twig->addFunction($name, new Twig_Function_Function($name));
+		if (substr(Twig_Environment::VERSION, 0, 1) == '2')
+            		$this->_twig->addFunction(new \Twig_Function($name, $name));
+		else
+            		$this->_twig->addFunction($name, new Twig_Function_Function($name));
 
 		return $this;
 	}
@@ -295,7 +298,10 @@ class Twiggy
 
 	public function register_filter($name)
 	{
-		$this->_twig->addFilter($name, new Twig_Filter_Function($name));
+		if (substr(Twig_Environment::VERSION, 0, 1) == '2')
+            		$this->_twig->addFilter(new \Twig_Filter($name, $name));
+		else
+            		$this->_twig->addFilter($name, new Twig_Filter_Function($name));
 
 		return $this;
 	}


### PR DESCRIPTION
Twig2 Fixes

- Due to Twig2 no longer allowing functions or globals to be added after the Lexer is initialised we need to do this prior to initializing the Lexer.
- Added checks and updated function calls

Tested with twig 2.4.3

### Please note

If you're using composer then you will need to comment out the following lines:

```
if ( !class_exists('ComposerAutoloaderInit') )
    require_once(TWIGGY_ROOT . '/vendor/Twig/lib/Twig/Autoloader.php');
    Twig_Autoloader::register();
```